### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Use **pip**:
 
     pip install kwargs-only
 
-Python 2.7 and 3.4-3.8 supported.
+Python 2.7 and 3.4 to 3.8 supported.
 
 Usage
 =====


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.